### PR TITLE
Create AI VA documentation site with checklists and dashboard

### DIFF
--- a/assets/checklist.css
+++ b/assets/checklist.css
@@ -1,0 +1,148 @@
+:root {
+  --accent: #2563eb;
+  --accent-light: #dbeafe;
+  --bg: #f8fafc;
+  --text: #0f172a;
+  --muted: #475569;
+  --border: #cbd5f5;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2.5rem 1.5rem 4rem;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+header {
+  background: white;
+  padding: 2rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 20px 60px -24px rgba(15, 23, 42, 0.25);
+  margin-bottom: 2rem;
+  border: 1px solid rgba(37, 99, 235, 0.1);
+}
+
+header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 2rem;
+}
+
+header p {
+  margin: 0;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+section {
+  background: white;
+  padding: 1.75rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 40px -24px rgba(15, 23, 42, 0.2);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  margin-bottom: 1.75rem;
+}
+
+section h2 {
+  margin-top: 0;
+  font-size: 1.3rem;
+  color: var(--accent);
+}
+
+section ul, section ol {
+  margin: 0;
+  padding-left: 1.15rem;
+}
+
+section li {
+  margin-bottom: 0.75rem;
+}
+
+.step {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: var(--accent-light);
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  margin-bottom: 1rem;
+}
+
+.step-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.step-title {
+  font-weight: 600;
+}
+
+.step-meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.acceptance {
+  margin-top: 0.75rem;
+  padding: 0.85rem;
+  background: white;
+  border-left: 4px solid var(--accent);
+  border-radius: 0.5rem;
+  color: var(--muted);
+}
+
+footer {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+footer a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+footer a:hover,
+footer a:focus {
+  text-decoration: underline;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+@media (min-width: 900px) {
+  body {
+    padding: 3rem 4rem 6rem;
+  }
+}
+[data-step] {
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+[data-step].open {
+  transform: scale(1.01);
+}
+
+[data-step] .acceptance {
+  display: none;
+}
+
+[data-step].open .acceptance {
+  display: block;
+}

--- a/assets/checklist.js
+++ b/assets/checklist.js
@@ -1,0 +1,19 @@
+(function () {
+  const steps = document.querySelectorAll('[data-step]');
+  steps.forEach((step) => {
+    const header = step.querySelector('.step-header');
+    if (!header) return;
+    header.addEventListener('click', () => {
+      step.classList.toggle('open');
+    });
+  });
+
+  const hash = window.location.hash;
+  if (hash) {
+    const target = document.querySelector(hash);
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      target.classList.add('open');
+    }
+  }
+})();

--- a/checklists.html
+++ b/checklists.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Checklists – VA Playbook</title>
+  <link rel="stylesheet" href="assets/checklist.css" />
+  <style>
+    body { max-width: 1100px; margin: 0 auto; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      padding: 0.8rem 0.9rem;
+      text-align: left;
+    }
+    th {
+      background: rgba(37, 99, 235, 0.08);
+    }
+    a.button {
+      display: inline-block;
+      padding: 0.4rem 0.8rem;
+      border-radius: 999px;
+      background: rgba(37, 99, 235, 0.14);
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Checklist Library</h1>
+    <p>Operational playbooks rendered as public HTML for VAs, clients, and automation references.</p>
+  </header>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="docs/system-overview.html">System Overview</a>
+    <a href="docs/airtable-model.html">Airtable Model</a>
+    <a href="dashboard.html">Dashboard</a>
+  </nav>
+  <section>
+    <table>
+      <thead>
+        <tr>
+          <th>Checklist</th>
+          <th>Category</th>
+          <th>SLA</th>
+          <th>Description</th>
+          <th>Link</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Meeting → Insight Brief</td>
+          <td>Meetings</td>
+          <td>6h</td>
+          <td>Converts Otter transcripts into executive briefs and action items.</td>
+          <td><a class="button" href="checklists/meetings-insight-brief.html">Open</a></td>
+        </tr>
+        <tr>
+          <td>Blog Refinement &amp; SEO</td>
+          <td>Blogs</td>
+          <td>12h</td>
+          <td>Transforms drafts into SEO-ready posts with distribution package.</td>
+          <td><a class="button" href="checklists/blog-refinement-seo.html">Open</a></td>
+        </tr>
+        <tr>
+          <td>Social Distribution Launch</td>
+          <td>Distribution</td>
+          <td>4h</td>
+          <td>Prepares platform-native copy, schedules posts, and tracks metrics.</td>
+          <td><a class="button" href="checklists/social-distribution.html">Open</a></td>
+        </tr>
+        <tr>
+          <td>Research Note → PRD</td>
+          <td>Research</td>
+          <td>10h</td>
+          <td>Converts research insights into a stakeholder-ready PRD.</td>
+          <td><a class="button" href="checklists/research-note-to-prd.html">Open</a></td>
+        </tr>
+        <tr>
+          <td>Image Pack Generation</td>
+          <td>Creative</td>
+          <td>6h</td>
+          <td>Produces on-brand visuals with metadata for reuse.</td>
+          <td><a class="button" href="checklists/image-pack-generation.html">Open</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  <footer>
+    <a href="docs/system-overview.html">Back to documentation</a>
+  </footer>
+</body>
+</html>

--- a/checklists/_template.html
+++ b/checklists/_template.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>{{CHECKLIST_NAME}} – VA Playbook</title>
+  <link rel="stylesheet" href="../assets/checklist.css" />
+</head>
+<body>
+  <header>
+    <h1>{{CHECKLIST_NAME}}</h1>
+    <p>Category: {{CATEGORY}} • SLA: {{SLA_HOURS}}h • Version: {{VERSION}}</p>
+  </header>
+  <section id="purpose">{{PURPOSE}}</section>
+  <section id="inputs">
+    <h2>Inputs Required</h2>
+    <ul><!-- render from schema --></ul>
+  </section>
+  <section id="steps">
+    <h2>Steps</h2>
+    <!-- ordered list with Tool, Prompt link, Done criteria -->
+  </section>
+  <section id="outputs">
+    <h2>Outputs &amp; Quality Gates</h2>
+    <ul><!-- artifacts + acceptance criteria --></ul>
+  </section>
+  <footer><a href="{{AIRTABLE_CHECKLIST_URL}}">Open in Airtable</a></footer>
+  <script src="../assets/checklist.js"></script>
+</body>
+</html>

--- a/checklists/blog-refinement-seo.html
+++ b/checklists/blog-refinement-seo.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Blog Refinement &amp; SEO – VA Playbook</title>
+  <link rel="stylesheet" href="../assets/checklist.css" />
+</head>
+<body>
+  <header>
+    <h1>Blog Refinement &amp; SEO</h1>
+    <p>Category: Blogs • SLA: 12h • Version: 1.0</p>
+  </header>
+  <section id="purpose">
+    <p>Elevate draft blog content into polished, search-optimized publications supported by visuals and distribution assets.</p>
+  </section>
+  <section id="inputs">
+    <h2>Inputs Required</h2>
+    <ul>
+      <li>Source draft (Markdown, Google Doc, or notes)</li>
+      <li>Target topic, audience, and positioning notes</li>
+      <li>SEO_BRIEF and BLOG_DRAFTER prompt references</li>
+      <li>Brand voice guardrails (tone, CTA, product mentions)</li>
+      <li>Distribution channels + publishing credentials</li>
+    </ul>
+  </section>
+  <section id="steps">
+    <h2>Steps</h2>
+    <div class="step" data-step id="step-1">
+      <div class="step-header">
+        <span class="step-title">1. Intake draft into Inputs</span>
+        <span class="step-meta">Tool: Airtable import • SLA: 10 min</span>
+      </div>
+      <div class="acceptance">Input record created with source link, summary, and owner; status set to <strong>Parsed</strong>.</div>
+    </div>
+    <div class="step" data-step id="step-2">
+      <div class="step-header">
+        <span class="step-title">2. Generate outline</span>
+        <span class="step-meta">Agent: OpenAI • Prompt: <span class="badge">MEETING_STRUCTURER</span> adapted • SLA: 15 min</span>
+      </div>
+      <div class="acceptance">Outline artifact listing H2/H3 structure with word counts saved to Airtable Artifacts.</div>
+    </div>
+    <div class="step" data-step id="step-3">
+      <div class="step-header">
+        <span class="step-title">3. Build SEO brief</span>
+        <span class="step-meta">Agent: OpenAI • Prompt: <span class="badge">SEO_BRIEF</span> • SLA: 20 min</span>
+      </div>
+      <div class="acceptance">SEO brief JSON stored with keywords, SERP intent, H2/H3 list, competitor URLs, and metadata options.</div>
+    </div>
+    <div class="step" data-step id="step-4">
+      <div class="step-header">
+        <span class="step-title">4. Draft V1</span>
+        <span class="step-meta">Agent: OpenAI • Prompt: <span class="badge">BLOG_DRAFTER</span> • SLA: 40 min</span>
+      </div>
+      <div class="acceptance">Markdown or Google Doc draft with TL;DR, CTA, and internal link placeholders uploaded to Artifacts.</div>
+    </div>
+    <div class="step" data-step id="step-5">
+      <div class="step-header">
+        <span class="step-title">5. Generate imagery</span>
+        <span class="step-meta">Agent: DALL·E / Midjourney • SLA: 30 min</span>
+      </div>
+      <div class="acceptance">Cover + 1&ndash;3 inline images generated with alt text and stored with file links.</div>
+    </div>
+    <div class="step" data-step id="step-6">
+      <div class="step-header">
+        <span class="step-title">6. Readability &amp; polish</span>
+        <span class="step-meta">Tools: Hemingway, Grammarly • SLA: 25 min</span>
+      </div>
+      <div class="acceptance">Readability score ≤ Grade 8, grammar issues resolved, voice compliance noted in Run log.</div>
+    </div>
+    <div class="step" data-step id="step-7">
+      <div class="step-header">
+        <span class="step-title">7. Metadata &amp; canonical setup</span>
+        <span class="step-meta">Tool: Airtable + CMS • SLA: 15 min</span>
+      </div>
+      <div class="acceptance">Canonical URL, meta title/description, OG image, and schema fields populated in CMS draft.</div>
+    </div>
+    <div class="step" data-step id="step-8">
+      <div class="step-header">
+        <span class="step-title">8. Publish &amp; cross-post</span>
+        <span class="step-meta">Tool: CMS + Buffer • SLA: 25 min</span>
+      </div>
+      <div class="acceptance">Article published on canonical channel, cross-post plan executed, Distribution rows created with scheduled timestamps.</div>
+    </div>
+    <div class="step" data-step id="step-9">
+      <div class="step-header">
+        <span class="step-title">9. Track distribution</span>
+        <span class="step-meta">Tool: Airtable Distribution • SLA: 10 min</span>
+      </div>
+      <div class="acceptance">Live URLs, UTMs, and initial performance metrics (if available) captured for each channel.</div>
+    </div>
+    <div class="step" data-step id="step-10">
+      <div class="step-header">
+        <span class="step-title">10. Retrospective &amp; time log</span>
+        <span class="step-meta">Tool: Airtable Runs/Timesheets • SLA: 10 min</span>
+      </div>
+      <div class="acceptance">Run notes document blockers/improvements; time entries submitted and checklist status set to <strong>Done</strong>.</div>
+    </div>
+  </section>
+  <section id="outputs">
+    <h2>Outputs &amp; Quality Gates</h2>
+    <ul>
+      <li>SEO brief artifact with structured JSON and download link</li>
+      <li>Blog draft doc with version + owner metadata</li>
+      <li>Image pack with filenames, alt text, and storage links</li>
+      <li>CMS metadata tracker and publishing confirmation</li>
+      <li>Distribution tracker populated with URLs, UTMs, and schedule</li>
+    </ul>
+  </section>
+  <footer><a href="https://airtable.com" target="_blank" rel="noopener">Open in Airtable</a></footer>
+  <script src="../assets/checklist.js"></script>
+</body>
+</html>

--- a/checklists/image-pack-generation.html
+++ b/checklists/image-pack-generation.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Image Pack Generation – VA Playbook</title>
+  <link rel="stylesheet" href="../assets/checklist.css" />
+</head>
+<body>
+  <header>
+    <h1>Image Pack Generation</h1>
+    <p>Category: Creative • SLA: 6h • Version: 0.8</p>
+  </header>
+  <section id="purpose">
+    <p>Create on-brand image sets that support articles, briefs, and social posts with consistent styling and metadata.</p>
+  </section>
+  <section id="inputs">
+    <h2>Inputs Required</h2>
+    <ul>
+      <li>Content brief or checklist run reference</li>
+      <li>Brand guidelines (colors, typography, logo usage)</li>
+      <li>Image size &amp; format requirements per channel</li>
+      <li>Prompt references for Midjourney/DALL·E</li>
+      <li>Storage destination (Drive folder or CDN)</li>
+    </ul>
+  </section>
+  <section id="steps">
+    <h2>Steps</h2>
+    <div class="step" data-step id="step-1">
+      <div class="step-header">
+        <span class="step-title">1. Define image needs</span>
+        <span class="step-meta">Tool: Airtable brief • SLA: 15 min</span>
+      </div>
+      <div class="acceptance">Shot list created with use cases, dimensions, style notes, and approval owner.</div>
+    </div>
+    <div class="step" data-step id="step-2">
+      <div class="step-header">
+        <span class="step-title">2. Generate concepts</span>
+        <span class="step-meta">Agent: Midjourney/DALL·E • SLA: 45 min</span>
+      </div>
+      <div class="acceptance">At least three concept variants per use case exported with prompt + seed logged for reproducibility.</div>
+    </div>
+    <div class="step" data-step id="step-3">
+      <div class="step-header">
+        <span class="step-title">3. Curate &amp; edit</span>
+        <span class="step-meta">Tool: Figma/Photoshop • SLA: 40 min</span>
+      </div>
+      <div class="acceptance">Final selections color-corrected, cropped, and annotated; layered files saved for future tweaks.</div>
+    </div>
+    <div class="step" data-step id="step-4">
+      <div class="step-header">
+        <span class="step-title">4. Publish image pack</span>
+        <span class="step-meta">Tool: Google Drive / CDN • SLA: 20 min</span>
+      </div>
+      <div class="acceptance">Images exported to required sizes (web, social, cover); filenames follow convention and stored in Drive folder linked to Artifacts.</div>
+    </div>
+    <div class="step" data-step id="step-5">
+      <div class="step-header">
+        <span class="step-title">5. Document metadata</span>
+        <span class="step-meta">Tool: Airtable Artifacts • SLA: 15 min</span>
+      </div>
+      <div class="acceptance">Each image logged with alt text, usage rights, aspect ratio, and recommended captions.</div>
+    </div>
+    <div class="step" data-step id="step-6">
+      <div class="step-header">
+        <span class="step-title">6. Close checklist</span>
+        <span class="step-meta">Automation: Airtable update • SLA: 5 min</span>
+      </div>
+      <div class="acceptance">Run status set to <strong>Done</strong>, time logged, and pack shared with downstream checklists.</div>
+    </div>
+  </section>
+  <section id="outputs">
+    <h2>Outputs &amp; Quality Gates</h2>
+    <ul>
+      <li>Image pack folder with cover + supporting images</li>
+      <li>Prompt log and seeds for regeneration</li>
+      <li>Editable source files (Figma/PSD)</li>
+      <li>Metadata sheet (alt text, captions, usage rights)</li>
+      <li>Checklist retrospective entry for improvements</li>
+    </ul>
+  </section>
+  <footer><a href="https://airtable.com" target="_blank" rel="noopener">Open in Airtable</a></footer>
+  <script src="../assets/checklist.js"></script>
+</body>
+</html>

--- a/checklists/meetings-insight-brief.html
+++ b/checklists/meetings-insight-brief.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Meeting → Insight Brief – VA Playbook</title>
+  <link rel="stylesheet" href="../assets/checklist.css" />
+</head>
+<body>
+  <header>
+    <h1>Meeting → Insight Brief</h1>
+    <p>Category: Meetings • SLA: 6h • Version: 1.1</p>
+  </header>
+  <section id="purpose">
+    <p>Convert raw meeting conversations into executive-ready briefs with structured insights, action items, and distribution-ready content.</p>
+  </section>
+  <section id="inputs">
+    <h2>Inputs Required</h2>
+    <ul>
+      <li>Otter transcript link + exported highlights</li>
+      <li>Meeting metadata (title, date, participants)</li>
+      <li>Associated project / client tag</li>
+      <li>Checklist run owner in Airtable</li>
+      <li>Prompt references for MEETING_STRUCTURER &amp; EXEC_SUMMARY</li>
+    </ul>
+  </section>
+  <section id="steps">
+    <h2>Steps</h2>
+    <div class="step" data-step id="step-1">
+      <div class="step-header">
+        <span class="step-title">1. Ingest transcript</span>
+        <span class="step-meta">Tool: Zapier webhook from Otter • SLA: 5 min</span>
+      </div>
+      <div class="acceptance">Input row created in Airtable &ldquo;Inputs&rdquo; table with transcript, highlights, owner, and status set to <strong>New</strong>.</div>
+    </div>
+    <div class="step" data-step id="step-2">
+      <div class="step-header">
+        <span class="step-title">2. Structure meeting</span>
+        <span class="step-meta">Agent: OpenAI • Prompt: <span class="badge">MEETING_STRUCTURER</span> • SLA: 8 min</span>
+      </div>
+      <div class="acceptance">JSON payload saved to Artifacts with purpose, agenda, decisions, owners, risks, and follow-ups. Validation check passes.</div>
+    </div>
+    <div class="step" data-step id="step-3">
+      <div class="step-header">
+        <span class="step-title">3. Draft executive brief</span>
+        <span class="step-meta">Agent: OpenAI → Google Doc • Prompt: <span class="badge">EXEC_SUMMARY</span> • SLA: 15 min</span>
+      </div>
+      <div class="acceptance">Google Doc draft (200&ndash;300 words) linked to the Run with correct formatting, context, decisions, risks, and next steps.</div>
+    </div>
+    <div class="step" data-step id="step-4">
+      <div class="step-header">
+        <span class="step-title">4. Push action items</span>
+        <span class="step-meta">Tool: Zapier → Airtable Tasks • SLA: 10 min</span>
+      </div>
+      <div class="acceptance">All owners and due dates logged as individual task records and linked back to the originating Input.</div>
+    </div>
+    <div class="step" data-step id="step-5">
+      <div class="step-header">
+        <span class="step-title">5. Generate distribution summary</span>
+        <span class="step-meta">Agent: OpenAI → Buffer draft • Prompt: <span class="badge">SOCIAL_SNIPPETS</span> • SLA: 12 min</span>
+      </div>
+      <div class="acceptance">Optional LinkedIn-ready summary stored in Distribution table with placeholders for scheduling.</div>
+    </div>
+    <div class="step" data-step id="step-6">
+      <div class="step-header">
+        <span class="step-title">6. QA pass</span>
+        <span class="step-meta">Tools: Hemingway + Grammarly • SLA: 12 min</span>
+      </div>
+      <div class="acceptance">Readability score ≤ Grade 7 documented; grammar/spell check completed and notes captured in Run.</div>
+    </div>
+    <div class="step" data-step id="step-7">
+      <div class="step-header">
+        <span class="step-title">7. Close the run</span>
+        <span class="step-meta">Automation: Airtable update • SLA: 3 min</span>
+      </div>
+      <div class="acceptance">Run status updated to <strong>Done</strong>, total minutes calculated, and artefact links verified.</div>
+    </div>
+  </section>
+  <section id="outputs">
+    <h2>Outputs &amp; Quality Gates</h2>
+    <ul>
+      <li>Structured meeting JSON artifact (versioned, checksum optional)</li>
+      <li>Executive brief Google Doc with approval field ready</li>
+      <li>Action items synced to Airtable Tasks with owners/dates</li>
+      <li>Distribution summary draft queued (if requested)</li>
+      <li>QA checklist log with readability score and reviewer notes</li>
+    </ul>
+  </section>
+  <footer><a href="https://airtable.com" target="_blank" rel="noopener">Open in Airtable</a></footer>
+  <script src="../assets/checklist.js"></script>
+</body>
+</html>

--- a/checklists/research-note-to-prd.html
+++ b/checklists/research-note-to-prd.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Research Note → PRD – VA Playbook</title>
+  <link rel="stylesheet" href="../assets/checklist.css" />
+</head>
+<body>
+  <header>
+    <h1>Research Note → Product Requirements Doc</h1>
+    <p>Category: Research • SLA: 10h • Version: 0.9</p>
+  </header>
+  <section id="purpose">
+    <p>Translate exploratory research notes into a validated PRD with user insights, requirements, and delivery milestones.</p>
+  </section>
+  <section id="inputs">
+    <h2>Inputs Required</h2>
+    <ul>
+      <li>Research notes (transcripts, highlights, or summary deck)</li>
+      <li>Target persona + problem statement</li>
+      <li>Existing product constraints or design principles</li>
+      <li>Prompt references: <span class="badge">MEETING_STRUCTURER</span>, <span class="badge">EXEC_SUMMARY</span></li>
+      <li>Approval routing list (PM, Eng lead, Design)</li>
+    </ul>
+  </section>
+  <section id="steps">
+    <h2>Steps</h2>
+    <div class="step" data-step id="step-1">
+      <div class="step-header">
+        <span class="step-title">1. Normalize research inputs</span>
+        <span class="step-meta">Tool: Airtable Inputs • SLA: 20 min</span>
+      </div>
+      <div class="acceptance">All source materials attached to Inputs record with tags, personas, and key dates captured.</div>
+    </div>
+    <div class="step" data-step id="step-2">
+      <div class="step-header">
+        <span class="step-title">2. Extract insights</span>
+        <span class="step-meta">Agent: OpenAI • Prompt: <span class="badge">MEETING_STRUCTURER</span> • SLA: 25 min</span>
+      </div>
+      <div class="acceptance">JSON artifact enumerating user goals, pain points, opportunity areas, and supporting quotes saved to Artifacts.</div>
+    </div>
+    <div class="step" data-step id="step-3">
+      <div class="step-header">
+        <span class="step-title">3. Draft PRD outline</span>
+        <span class="step-meta">Agent: OpenAI • SLA: 20 min</span>
+      </div>
+      <div class="acceptance">Outline includes problem statement, goals, success metrics, requirements, assumptions, and open questions.</div>
+    </div>
+    <div class="step" data-step id="step-4">
+      <div class="step-header">
+        <span class="step-title">4. Author PRD v1</span>
+        <span class="step-meta">Agent: OpenAI → Google Doc • SLA: 60 min</span>
+      </div>
+      <div class="acceptance">Draft PRD doc with sections fleshed out, requirement table, risks, and timeline placeholder.</div>
+    </div>
+    <div class="step" data-step id="step-5">
+      <div class="step-header">
+        <span class="step-title">5. Stakeholder review loop</span>
+        <span class="step-meta">Tool: Google Docs comments • SLA: 90 min</span>
+      </div>
+      <div class="acceptance">Feedback requested from PM, Eng, Design; comments resolved or documented with owners in Run Steps.</div>
+    </div>
+    <div class="step" data-step id="step-6">
+      <div class="step-header">
+        <span class="step-title">6. Version final PRD</span>
+        <span class="step-meta">Tool: Google Docs + Airtable Artifacts • SLA: 15 min</span>
+      </div>
+      <div class="acceptance">Version number incremented, change log recorded, final link stored with approval flag toggled.</div>
+    </div>
+    <div class="step" data-step id="step-7">
+      <div class="step-header">
+        <span class="step-title">7. Sync tasks &amp; roadmap</span>
+        <span class="step-meta">Tool: Zapier → Airtable/Project tool • SLA: 25 min</span>
+      </div>
+      <div class="acceptance">Requirements translated into tasks with owners/dates; roadmap updated and linked in Artifacts.</div>
+    </div>
+    <div class="step" data-step id="step-8">
+      <div class="step-header">
+        <span class="step-title">8. Close checklist</span>
+        <span class="step-meta">Automation: Airtable update • SLA: 5 min</span>
+      </div>
+      <div class="acceptance">Run marked <strong>Done</strong>, timesheet entries logged, summary shared with leadership.</div>
+    </div>
+  </section>
+  <section id="outputs">
+    <h2>Outputs &amp; Quality Gates</h2>
+    <ul>
+      <li>Insight JSON artifact with citations to source notes</li>
+      <li>PRD v1 Google Doc (comment-ready) + final approved version</li>
+      <li>Requirements-to-task mapping sheet</li>
+      <li>Risk register with owners and mitigation status</li>
+      <li>Roadmap link + milestone tracker aligned with PRD</li>
+    </ul>
+  </section>
+  <footer><a href="https://airtable.com" target="_blank" rel="noopener">Open in Airtable</a></footer>
+  <script src="../assets/checklist.js"></script>
+</body>
+</html>

--- a/checklists/social-distribution.html
+++ b/checklists/social-distribution.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Social Distribution Launch – VA Playbook</title>
+  <link rel="stylesheet" href="../assets/checklist.css" />
+</head>
+<body>
+  <header>
+    <h1>Social Distribution Launch</h1>
+    <p>Category: Distribution • SLA: 4h • Version: 1.0</p>
+  </header>
+  <section id="purpose">
+    <p>Transform approved artifacts into platform-native posts, schedule distribution, and capture performance signals.</p>
+  </section>
+  <section id="inputs">
+    <h2>Inputs Required</h2>
+    <ul>
+      <li>Approved artifact link (blog, brief, or asset)</li>
+      <li>Canonical URL + UTM parameters</li>
+      <li>Distribution channel list with posting windows</li>
+      <li>Prompt reference: <span class="badge">SOCIAL_SNIPPETS</span></li>
+      <li>Brand voice + compliance checklist</li>
+    </ul>
+  </section>
+  <section id="steps">
+    <h2>Steps</h2>
+    <div class="step" data-step id="step-1">
+      <div class="step-header">
+        <span class="step-title">1. Confirm artifact approval</span>
+        <span class="step-meta">Tool: Airtable Artifacts • SLA: 5 min</span>
+      </div>
+      <div class="acceptance">Artifact status = Approved, linked runs verified, and publishing notes captured.</div>
+    </div>
+    <div class="step" data-step id="step-2">
+      <div class="step-header">
+        <span class="step-title">2. Generate channel copy</span>
+        <span class="step-meta">Agent: OpenAI • Prompt: <span class="badge">SOCIAL_SNIPPETS</span> • SLA: 12 min</span>
+      </div>
+      <div class="acceptance">LinkedIn post, X thread, and newsletter blurb created with canonical URL placeholder.</div>
+    </div>
+    <div class="step" data-step id="step-3">
+      <div class="step-header">
+        <span class="step-title">3. Localize per channel</span>
+        <span class="step-meta">Tool: Manual edit + Grammarly • SLA: 15 min</span>
+      </div>
+      <div class="acceptance">Voice/tone check complete, hashtags reviewed, CTA consistent, compliance cleared.</div>
+    </div>
+    <div class="step" data-step id="step-4">
+      <div class="step-header">
+        <span class="step-title">4. Schedule posts</span>
+        <span class="step-meta">Tool: Buffer / Hypefury • SLA: 15 min</span>
+      </div>
+      <div class="acceptance">Posts scheduled with correct times, images, and shortened URLs; Distribution rows created per channel.</div>
+    </div>
+    <div class="step" data-step id="step-5">
+      <div class="step-header">
+        <span class="step-title">5. Update Airtable Distribution</span>
+        <span class="step-meta">Automation: Zapier sync • SLA: 5 min</span>
+      </div>
+      <div class="acceptance">Distribution table populated with scheduled timestamp, platform, and post URL placeholders.</div>
+    </div>
+    <div class="step" data-step id="step-6">
+      <div class="step-header">
+        <span class="step-title">6. Monitor publishing</span>
+        <span class="step-meta">Tool: Buffer analytics • SLA: 30 min (rolling)</span>
+      </div>
+      <div class="acceptance">Published time recorded, post URLs confirmed live, initial impressions/clicks logged after 24h.</div>
+    </div>
+    <div class="step" data-step id="step-7">
+      <div class="step-header">
+        <span class="step-title">7. Feedback loop</span>
+        <span class="step-meta">Tool: Airtable notes • SLA: 8 min</span>
+      </div>
+      <div class="acceptance">Key learnings, performance highlights, and follow-up experiments documented in Run.</div>
+    </div>
+    <div class="step" data-step id="step-8">
+      <div class="step-header">
+        <span class="step-title">8. Close checklist</span>
+        <span class="step-meta">Automation: Airtable update • SLA: 3 min</span>
+      </div>
+      <div class="acceptance">Run status set to <strong>Done</strong>, minutes logged, metrics forwarded to dashboard.</div>
+    </div>
+  </section>
+  <section id="outputs">
+    <h2>Outputs &amp; Quality Gates</h2>
+    <ul>
+      <li>Channel-specific copy deck (LinkedIn, X, newsletter)</li>
+      <li>Scheduled posts with assets attached</li>
+      <li>Distribution table entries with UTMs + tracking tags</li>
+      <li>Initial performance metrics logged for dashboard ingest</li>
+      <li>Run retrospective captured with optimization ideas</li>
+    </ul>
+  </section>
+  <footer><a href="https://airtable.com" target="_blank" rel="noopener">Open in Airtable</a></footer>
+  <script src="../assets/checklist.js"></script>
+</body>
+</html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>AI VA Dashboard – VA Playbook</title>
+  <link rel="stylesheet" href="assets/checklist.css" />
+  <style>
+    body { max-width: 1100px; margin: 0 auto; }
+    .kpi-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1.2rem;
+    }
+    .card {
+      background: white;
+      padding: 1.5rem;
+      border-radius: 1rem;
+      box-shadow: 0 18px 50px -30px rgba(15, 23, 42, 0.4);
+      border: 1px solid rgba(15, 23, 42, 0.08);
+    }
+    h2 {
+      color: var(--accent);
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1rem;
+    }
+    th, td {
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      padding: 0.7rem 0.8rem;
+      text-align: left;
+    }
+    th {
+      background: rgba(37, 99, 235, 0.08);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>AI VA Dashboard Blueprint</h1>
+    <p>Visualize checklist throughput, time investment, and publishing outputs in a single interface.</p>
+  </header>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="docs/system-overview.html">System Overview</a>
+    <a href="docs/airtable-model.html">Airtable Model</a>
+    <a href="checklists.html">Checklists</a>
+  </nav>
+  <section>
+    <h2>Header KPIs</h2>
+    <div class="kpi-grid">
+      <div class="card">
+        <h3>Runs In Progress</h3>
+        <p>Today&apos;s active runs vs. due count with SLA countdown per checklist.</p>
+      </div>
+      <div class="card">
+        <h3>Average Minutes / Checklist</h3>
+        <p>Rolling 7-day and 30-day averages derived from Run totals.</p>
+      </div>
+      <div class="card">
+        <h3>Output Velocity</h3>
+        <p>Artifacts produced per week segmented by checklist category.</p>
+      </div>
+      <div class="card">
+        <h3>Publish Rate</h3>
+        <p>Scheduled vs. published ratio with channel breakdown.</p>
+      </div>
+      <div class="card">
+        <h3>Quality Flags</h3>
+        <p>Readability targets, approval status, and QA exceptions aggregated from Runs.</p>
+      </div>
+    </div>
+  </section>
+  <section>
+    <h2>Pipeline Board</h2>
+    <div class="card">
+      <p>Kanban grouping Runs by status (New → In Progress → Review → Done → Blocked) with checklist tags for prioritization.</p>
+    </div>
+  </section>
+  <section>
+    <h2>Time &amp; Load</h2>
+    <div class="card">
+      <p>Timesheet heatmap by person and project, plus totals for today and the current week.</p>
+      <p>Blend auto-calculated run durations with manual entries for QA or edits.</p>
+    </div>
+  </section>
+  <section>
+    <h2>Run Detail Panel</h2>
+    <div class="card">
+      <ul>
+        <li>Step timeline with timestamps, owner, duration, and status.</li>
+        <li>Linked artifacts preview (Docs, images, distribution drafts).</li>
+        <li>Current blocker notes and SLA countdown indicator.</li>
+      </ul>
+    </div>
+  </section>
+  <section>
+    <h2>Publishing Tracker</h2>
+    <div class="card">
+      <p>Calendar view showing scheduled posts with channel icons, state (queued/published/error), and quick links to URLs.</p>
+    </div>
+  </section>
+  <section>
+    <h2>SEO Performance Panel</h2>
+    <div class="card">
+      <p>List the last 10 posts with primary keywords, SERP rank placeholder, impressions, and click-through metrics.</p>
+    </div>
+  </section>
+  <section>
+    <h2>Search &amp; Filters</h2>
+    <div class="card">
+      <p>Global search by Input, Project, Tag, or Owner. Filters for checklist, status, channel, and SLA range.</p>
+    </div>
+  </section>
+  <section>
+    <h2>Key Formulas</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Metric</th>
+          <th>Formula / Source</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Total Minutes</td>
+          <td><code>DATETIME_DIFF(End, Start, 'minutes')</code> aggregated per run.</td>
+        </tr>
+        <tr>
+          <td>Checklist Efficiency</td>
+          <td><code>Total Minutes / Completed Steps</code></td>
+        </tr>
+        <tr>
+          <td>Publish Rate</td>
+          <td><code>Count(Published) / Count(Scheduled)</code></td>
+        </tr>
+        <tr>
+          <td>Velocity</td>
+          <td>Artifacts per week (Airtable summary block or Looker Studio chart).</td>
+        </tr>
+        <tr>
+          <td>Quality Score</td>
+          <td>Weighted average of readability, approvals, and QA checklist completion.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  <footer>
+    <a href="docs/system-overview.html">Back to documentation</a>
+  </footer>
+</body>
+</html>

--- a/docs/airtable-model.html
+++ b/docs/airtable-model.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Airtable Data Model – VA Playbook</title>
+  <link rel="stylesheet" href="../assets/checklist.css" />
+  <style>
+    body { max-width: 1100px; margin: 0 auto; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 1.5rem;
+    }
+    th, td {
+      border: 1px solid rgba(15, 23, 42, 0.1);
+      padding: 0.65rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: rgba(37, 99, 235, 0.08);
+    }
+    pre {
+      background: #0f172a;
+      color: #f8fafc;
+      padding: 1rem 1.25rem;
+      border-radius: 0.75rem;
+      overflow-x: auto;
+      box-shadow: 0 12px 40px -30px rgba(15, 23, 42, 0.7);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Airtable Data Model</h1>
+    <p>Blueprint for tables, key fields, and formulas powering the AI VA workflows.</p>
+  </header>
+  <nav>
+    <a href="../index.html">Home</a>
+    <a href="system-overview.html">System Overview</a>
+    <a href="tools-agents.html">Tools &amp; Agents</a>
+    <a href="airtable-model.html">Airtable Model</a>
+  </nav>
+  <section>
+    <h2>Core Tables</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Table</th>
+          <th>Purpose</th>
+          <th>Key Fields</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Inputs</td>
+          <td>One row per meeting, note, or draft intake.</td>
+          <td>Input ID (PK), Source, Otter Link, Title, Owner, Project, Raw Transcript, Highlights, Status, Tags, Created At</td>
+        </tr>
+        <tr>
+          <td>Checklists</td>
+          <td>Defines reusable processes and links to rendered HTML pages.</td>
+          <td>Checklist ID, Name, Category, Steps (JSON), SLA (hrs), Default Owner, Version, HTML Path, Active?</td>
+        </tr>
+        <tr>
+          <td>Runs</td>
+          <td>Instance of a checklist tied to an input.</td>
+          <td>Run ID, Checklist ID, Input ID, Assignee, Start/End Time, Total Minutes, Step Count, Completed Steps, Status, Artifacts, Notes</td>
+        </tr>
+        <tr>
+          <td>Run Steps</td>
+          <td>Granular tracking for each step executed.</td>
+          <td>Run Step ID, Run ID, Step #, Name, Tool/Agent, Prompt Template, Inputs, Outputs, Duration, Status, Error, Reruns</td>
+        </tr>
+        <tr>
+          <td>Artifacts</td>
+          <td>Stores all deliverables produced across workflows.</td>
+          <td>Artifact ID, Type, Format, Storage Link, Version, Author, Approved?, Linked Runs, Hash/Checksum</td>
+        </tr>
+        <tr>
+          <td>Distribution</td>
+          <td>Manages publishing per channel.</td>
+          <td>Distribution ID, Artifact ID, Channel, Post Title, Post URL, Scheduled At, Published At, UTM, Status, Metrics</td>
+        </tr>
+        <tr>
+          <td>Prompts</td>
+          <td>Version-controlled prompt templates.</td>
+          <td>Prompt ID, Name, Purpose, Template, Inputs Required, Model/Params, Owner, Version, Last Updated</td>
+        </tr>
+        <tr>
+          <td>Timesheets</td>
+          <td>Manual time entries for VAs or reviewers.</td>
+          <td>Entry ID, Person, Run ID/Task, Start, End, Minutes, Notes</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  <section>
+    <h2>Step JSON Template</h2>
+    <pre>
+[
+  {
+    "step": 1,
+    "name": "Ingest transcript from Otter",
+    "tool": "Zapier",
+    "inputs_required": ["otter_url"],
+    "prompt_ref": null,
+    "acceptance": "Input row created with transcript & highlights",
+    "sla_min": 5
+  }
+]
+    </pre>
+    <p>Store the JSON inside the <strong>Steps</strong> field for each checklist to enable automation rendering.</p>
+  </section>
+  <section>
+    <h2>Formulas &amp; KPIs</h2>
+    <ul>
+      <li><strong>Total Minutes:</strong> <code>DATETIME_DIFF(End, Start, 'minutes')</code></li>
+      <li><strong>Step On-Time?:</strong> <code>IF(Duration &lt;= SLA_step, "✅", "⚠️")</code></li>
+      <li><strong>Checklist Efficiency:</strong> <code>Total Minutes / Completed Steps</code></li>
+      <li><strong>Publish Rate:</strong> <code>Count(Published) / Count(Scheduled)</code></li>
+      <li><strong>Velocity:</strong> Rolling count of artifacts produced per week via Airtable summary or Looker Studio.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>Time &amp; Task Tracking</h2>
+    <p>Each run step logs start/end times, enabling automatic duration calculations. Zapier or Opal pushes durations into Run Steps, while Airtable rollups supply Run-level totals. Manual edits and reviews are captured in Timesheets for blended accuracy.</p>
+  </section>
+  <section>
+    <h2>Distribution Feedback Loop</h2>
+    <p>When Distribution status shifts to <em>Published</em>, Zapier updates metrics fields and posts links back into the Dashboard. Failed publications trigger <em>Error</em> status with Slack notifications for follow-up.</p>
+  </section>
+  <footer>
+    <a href="../dashboard.html">Dashboard Design</a>
+  </footer>
+</body>
+</html>

--- a/docs/system-overview.html
+++ b/docs/system-overview.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>System Overview – VA Playbook</title>
+  <link rel="stylesheet" href="../assets/checklist.css" />
+  <style>
+    body { max-width: 1100px; margin: 0 auto; }
+    pre {
+      background: #0f172a;
+      color: #f8fafc;
+      padding: 1rem 1.5rem;
+      border-radius: 0.75rem;
+      overflow-x: auto;
+      box-shadow: 0 12px 40px -24px rgba(15, 23, 42, 0.8);
+    }
+    nav a {
+      margin-right: 1rem;
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 600;
+    }
+    nav {
+      margin-bottom: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>AI VA System Overview</h1>
+    <p>Understand how meetings flow from capture to publishing while maintaining visibility into progress and metrics.</p>
+  </header>
+  <nav>
+    <a href="../index.html">Home</a>
+    <a href="system-overview.html">System Overview</a>
+    <a href="tools-agents.html">Tools &amp; Agents</a>
+    <a href="airtable-model.html">Airtable Model</a>
+  </nav>
+  <section>
+    <h2>System at a Glance</h2>
+    <p>The system is orchestrated as a sequence of interoperable services. Meetings and source material are captured, structured, and converted into publishable artifacts with audit trails.</p>
+    <pre>
+flowchart LR
+A[Meeting / Source] -->|audio/text| B[Otter]
+B -->|export summary + transcript| C[Airtable: Inputs]
+C -->|Zapier trigger (new record)| D[Agent Orchestrator (Opal or custom)]
+D -->|structured artifacts| E[Airtable: Artifacts]
+E -->|Zapier| F[Google Docs (drafts)]
+F -->|review→approved| G[CMS/Channels: LinkedIn, Medium, Substack, Blog]
+G -->|post URLs| H[Airtable: Distribution]
+D -->|metrics| I[Timesheet + Run Logs]
+I --> J[Dashboard (web app)]
+E --> J
+H --> J
+C --> J
+    </pre>
+    <p>Each block represents a managed integration. Airtable acts as the system of record for inputs, checklists, outputs, and distribution.</p>
+  </section>
+  <section>
+    <h2>End-to-End Workflow</h2>
+    <ol>
+      <li><strong>Capture:</strong> Otter ingests meeting recordings and shares transcripts/highlights.</li>
+      <li><strong>Normalize:</strong> Zapier stores the conversation into Airtable Inputs, tagging owners, projects, and timestamps.</li>
+      <li><strong>Orchestrate:</strong> Google Opal (or custom orchestrator) kicks off the appropriate checklist run, invoking specialized agents.</li>
+      <li><strong>Produce:</strong> Agents create structured artifacts (briefs, drafts, assets) that are stored in Airtable and Google Docs.</li>
+      <li><strong>Distribute:</strong> Approved content moves through distribution automations into CMS and social channels.</li>
+      <li><strong>Measure:</strong> Run metrics, time spent, and publishing data flow back into dashboards for visibility.</li>
+    </ol>
+  </section>
+  <section>
+    <h2>Resilience &amp; Monitoring</h2>
+    <ul>
+      <li><strong>Error handling:</strong> Failed steps set the Run status to <em>Blocked</em> and alert the assignee with context and logs.</li>
+      <li><strong>Version control:</strong> Prompts, artifacts, and runs carry version numbers to track evolution of the playbook.</li>
+      <li><strong>Security:</strong> API keys remain in secrets managers; transcripts are sanitized prior to external API calls.</li>
+      <li><strong>Governance:</strong> Human approval steps gate distribution to ensure compliance and final QA.</li>
+    </ul>
+  </section>
+  <footer>
+    <a href="../dashboard.html">View Dashboard Design</a>
+  </footer>
+</body>
+</html>

--- a/docs/tools-agents.html
+++ b/docs/tools-agents.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Tools &amp; Agents – VA Playbook</title>
+  <link rel="stylesheet" href="../assets/checklist.css" />
+  <style>
+    body { max-width: 1100px; margin: 0 auto; }
+    dl {
+      display: grid;
+      grid-template-columns: minmax(200px, 280px) 1fr;
+      gap: 0.75rem 1.5rem;
+    }
+    dt {
+      font-weight: 700;
+      color: var(--accent);
+    }
+    dd {
+      margin: 0;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1rem;
+    }
+    th, td {
+      border: 1px solid rgba(15, 23, 42, 0.1);
+      padding: 0.75rem;
+      text-align: left;
+    }
+    th {
+      background: rgba(37, 99, 235, 0.08);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Tools, Agents &amp; Workflows</h1>
+    <p>Recommended stack and automations that bring the AI-powered VA to life.</p>
+  </header>
+  <nav>
+    <a href="../index.html">Home</a>
+    <a href="system-overview.html">System Overview</a>
+    <a href="tools-agents.html">Tools &amp; Agents</a>
+    <a href="airtable-model.html">Airtable Model</a>
+  </nav>
+  <section>
+    <h2>Capture &amp; Transcription</h2>
+    <dl>
+      <dt>Otter</dt>
+      <dd>Primary source for meeting transcripts, highlights, speaker detection, and timestamps.</dd>
+      <dt>Google Meet / Zoom</dt>
+      <dd>Native recordings optionally routed to Otter for automatic ingestion.</dd>
+    </dl>
+  </section>
+  <section>
+    <h2>Orchestration</h2>
+    <dl>
+      <dt>Google Opal</dt>
+      <dd>Multi-step agentic runner coordinating prompts, tool use, and Airtable updates.</dd>
+      <dt>Zapier / n8n / Make</dt>
+      <dd>Event-driven glue that syncs Airtable, Docs, Calendars, and CMS workflows.</dd>
+      <dt>Python Microservice</dt>
+      <dd>Optional FastAPI service for custom webhooks, retries, or long-running tasks.</dd>
+    </dl>
+  </section>
+  <section>
+    <h2>Storage &amp; Tracking</h2>
+    <dl>
+      <dt>Airtable</dt>
+      <dd>Source of truth for Inputs, Checklists, Runs, Run Steps, Artifacts, Distribution, Prompts, and Timesheets.</dd>
+      <dt>Google Drive / Docs</dt>
+      <dd>Living drafts and collaboration surface for humans-in-the-loop.</dd>
+      <dt>MongoDB</dt>
+      <dd>Optional vector store for long-term retrieval across meeting history.</dd>
+    </dl>
+  </section>
+  <section>
+    <h2>AI Writing &amp; Editing</h2>
+    <dl>
+      <dt>OpenAI</dt>
+      <dd>Drafting, structuring, SEO ideation, and summaries using tuned prompt library.</dd>
+      <dt>Hemingway</dt>
+      <dd>Enforces readability targets for briefs and blog drafts.</dd>
+      <dt>Grammarly</dt>
+      <dd>Ensures tone consistency and final polish.</dd>
+      <dt>Midjourney / DALL·E</dt>
+      <dd>Generates supporting visuals with prompt discipline.</dd>
+      <dt>Surfer SEO / Clearscope</dt>
+      <dd>Optional keyword and SERP gap analysis for advanced optimization.</dd>
+    </dl>
+  </section>
+  <section>
+    <h2>Publishing &amp; Analytics</h2>
+    <dl>
+      <dt>Channels</dt>
+      <dd>LinkedIn, Medium, Substack, Ghost/Next.js blog, plus Buffer or Hypefury for scheduling.</dd>
+      <dt>Analytics</dt>
+      <dd>Airtable Interfaces for quick dashboards; Metabase or Looker Studio for deeper analysis.</dd>
+    </dl>
+  </section>
+  <section>
+    <h2>Prompt Library</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Prompt</th>
+          <th>Purpose</th>
+          <th>Primary Output</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>MEETING_STRUCTURER</td>
+          <td>Extract purpose, agenda, decisions, owners, risks from transcripts.</td>
+          <td>Structured JSON summary</td>
+        </tr>
+        <tr>
+          <td>EXEC_SUMMARY</td>
+          <td>Create 200–300 word executive brief with context, decisions, risks, and next steps.</td>
+          <td>Google Doc or Markdown brief</td>
+        </tr>
+        <tr>
+          <td>SEO_BRIEF</td>
+          <td>Compile keywords, SERP intent, headings, questions, and competitor references.</td>
+          <td>SEO brief JSON</td>
+        </tr>
+        <tr>
+          <td>BLOG_DRAFTER</td>
+          <td>Draft 1,200–1,800 word posts aligned to SEO brief with TL;DR and CTA.</td>
+          <td>Article draft</td>
+        </tr>
+        <tr>
+          <td>SOCIAL_SNIPPETS</td>
+          <td>Produce LinkedIn post, X thread, and newsletter blurb tied to canonical URL.</td>
+          <td>Channel-ready copy bundle</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  <section>
+    <h2>Workflow Wiring</h2>
+    <ul>
+      <li><strong>Triggers:</strong> Otter conversations → Inputs, Inputs parsed → Opal job, Artifacts approved → Google Doc templates, Distribution queued → Buffer scheduling.</li>
+      <li><strong>Actions:</strong> Run agents with checklist context, persist run steps, upload artifacts, update statuses and timestamps.</li>
+      <li><strong>Error Handling:</strong> Failed steps flag runs as <em>Blocked</em>, store error context, and notify stakeholders via Slack or email.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>Example Agents</h2>
+    <ul>
+      <li><strong>Ingestion Agent:</strong> Validates Otter link, fetches transcript, and cleans noise.</li>
+      <li><strong>Structurer Agent:</strong> Applies MEETING_STRUCTURER to produce JSON insights.</li>
+      <li><strong>Summarizer Agent:</strong> Runs EXEC_SUMMARY and publishes to Google Doc.</li>
+      <li><strong>SEO Agent:</strong> Builds SEO_BRIEF and passes data to drafting agent.</li>
+      <li><strong>Drafting Agent:</strong> Uses BLOG_DRAFTER to produce long-form content with placeholders.</li>
+      <li><strong>Image Agent:</strong> Generates visual concepts and alt text.</li>
+      <li><strong>Distribution Agent:</strong> Prepares multi-channel copy with UTMs.</li>
+      <li><strong>Analytics Agent:</strong> Backfills metrics into Airtable for dashboards.</li>
+    </ul>
+  </section>
+  <section>
+    <h2>Security &amp; Governance</h2>
+    <ul>
+      <li>Store API keys in Opal or a dedicated secrets manager, never inside Airtable fields.</li>
+      <li>Mask personally identifiable information before sending transcripts to third-party models.</li>
+      <li>Version prompts and attach prompt IDs plus versions to each artifact for traceability.</li>
+      <li>Require human approval before distribution to public channels.</li>
+    </ul>
+  </section>
+  <footer>
+    <a href="../dashboard.html">Explore Dashboard</a>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,89 @@
-VA
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>AI VA Playbook</title>
+  <link rel="stylesheet" href="assets/checklist.css" />
+  <style>
+    body { max-width: 1100px; margin: 0 auto; }
+    .hero {
+      text-align: center;
+      padding: 2rem 1rem 3rem;
+    }
+    .hero h1 {
+      font-size: 2.8rem;
+      margin-bottom: 0.5rem;
+    }
+    .hero p {
+      margin: 0 auto;
+      max-width: 720px;
+      color: var(--muted);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+    }
+    .card {
+      background: white;
+      padding: 1.8rem;
+      border-radius: 1.25rem;
+      box-shadow: 0 22px 60px -32px rgba(15, 23, 42, 0.45);
+      border: 1px solid rgba(15, 23, 42, 0.08);
+    }
+    .card h2 {
+      margin-top: 0;
+      color: var(--accent);
+    }
+    .card p {
+      color: var(--muted);
+    }
+    .card a {
+      display: inline-block;
+      margin-top: 1rem;
+      font-weight: 600;
+      color: var(--accent);
+      text-decoration: none;
+    }
+    .card a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <h1>AI Virtual Assistant Playbook</h1>
+    <p>A centralized guide for running AI-powered checklists, orchestrating automations, and tracking outcomes across meetings, content, and distribution.</p>
+  </header>
+  <section class="grid">
+    <article class="card">
+      <h2>System Overview</h2>
+      <p>See how Otter, Airtable, Opal, and publishing channels connect to deliver insights end-to-end.</p>
+      <a href="docs/system-overview.html">Explore the flow →</a>
+    </article>
+    <article class="card">
+      <h2>Tools &amp; Agents</h2>
+      <p>Dive into recommended stack, prompt library, and the agents powering each workflow.</p>
+      <a href="docs/tools-agents.html">Review the stack →</a>
+    </article>
+    <article class="card">
+      <h2>Airtable Model</h2>
+      <p>Understand the tables, fields, formulas, and JSON schemas that keep the system aligned.</p>
+      <a href="docs/airtable-model.html">Open the data model →</a>
+    </article>
+    <article class="card">
+      <h2>Checklist Library</h2>
+      <p>Access detailed step-by-step checklists for briefs, blogs, distribution, research, and creative.</p>
+      <a href="checklists.html">Launch checklists →</a>
+    </article>
+    <article class="card">
+      <h2>Dashboard Blueprint</h2>
+      <p>Monitor throughput, time spent, publishing velocity, and quality flags at a glance.</p>
+      <a href="dashboard.html">View dashboard →</a>
+    </article>
+  </section>
+  <footer style="text-align:center; margin-top:3rem; color:var(--muted);">
+    <p>Built for rapid iteration. Update prompts, automations, and SLAs as the AI VA evolves.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the landing page to highlight the VA playbook resources and navigation
- add dedicated documentation for the system overview, tooling stack, and Airtable data model plus a dashboard blueprint
- publish reusable checklist pages with shared styling/script support for five core workflows

## Testing
- not run (static HTML content)


------
https://chatgpt.com/codex/tasks/task_e_68d97b3d08908325a8055c3232ed3353